### PR TITLE
Use Node 6.x for base Docker image, as Node 9+ is not supported at the moment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:boron
 MAINTAINER enrico.simonetti@gmail.com
 
 RUN npm install -g mocha co-mocha


### PR DESCRIPTION
Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>

Currently, Thorn only supports Node 6.x. A future release might include support for Node 8.x+.